### PR TITLE
Replace has_git by test_requires_git

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -42,7 +42,7 @@ my $builder = $class->new(
 	build_requires       =>
 	{
 		'Test::FailWarnings'   => 0,
-		'Test::Git'            => 0,
+		'Test::Requires::Git'  => 1.005,
 		'Test::More'           => 0.94,
 	},
 	requires             =>

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -14,7 +14,7 @@ WriteMakefile
   'PREREQ_PM' => {
                    'Try::Tiny' => 0,
                    'App::GitHooks' => 0,
-                   'Test::Git' => 0,
+                   'Test::Requires::Git' => 1.005,
                    'Test::FailWarnings' => 0,
                    'Log::Any' => 0,
                    'Test::More' => '0.94',

--- a/t/01-git_version.t
+++ b/t/01-git_version.t
@@ -4,11 +4,11 @@ use strict;
 use warnings;
 
 use Test::FailWarnings -allow_deps => 1;
-use Test::Git;
+use Test::Requires::Git;
 use Test::More;
 
 
-has_git();
+test_requires_git();
 
 plan( tests => 2 );
 


### PR DESCRIPTION
Test::Git::has_git is obsolete and replaced by
Test::Requires::Git::test_requires_git.
